### PR TITLE
[UI] Show toasts when collapsed

### DIFF
--- a/Tracer.xcodeproj/project.pbxproj
+++ b/Tracer.xcodeproj/project.pbxproj
@@ -60,6 +60,11 @@
 		D418D10420AC618A006369C0 /* TraceUIContainerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D418D10320AC618A006369C0 /* TraceUIContainerPresenter.swift */; };
 		D418D10620AC68B2006369C0 /* TraceAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D418D10520AC68B2006369C0 /* TraceAnimation.swift */; };
 		D418D12320ACDB76006369C0 /* Dictionary+AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = D418D12220ACDB76006369C0 /* Dictionary+AttributedString.swift */; };
+		D43ADBD720AF60DF007519F7 /* TraceUIToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ADBD620AF60DF007519F7 /* TraceUIToastView.swift */; };
+		D43ADBD920AF60EB007519F7 /* TraceUIToastPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ADBD820AF60EB007519F7 /* TraceUIToastPresenter.swift */; };
+		D43ADBDB20AF60F9007519F7 /* TraceUIToastViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ADBDA20AF60F9007519F7 /* TraceUIToastViewModel.swift */; };
+		D43ADBDD20AF6321007519F7 /* TraceUIToastQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ADBDC20AF6321007519F7 /* TraceUIToastQueue.swift */; };
+		D43ADBDF20AF64A5007519F7 /* TraceUIToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43ADBDE20AF64A5007519F7 /* TraceUIToast.swift */; };
 		D45FEC65209345380084DF96 /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45FEC64209345380084DF96 /* Trace.swift */; };
 		D45FEC69209346220084DF96 /* TraceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45FEC68209346220084DF96 /* TraceItem.swift */; };
 		D463175D209232FD0008A1BC /* Tracer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4631753209232FD0008A1BC /* Tracer.framework */; };
@@ -142,6 +147,11 @@
 		D418D10320AC618A006369C0 /* TraceUIContainerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceUIContainerPresenter.swift; sourceTree = "<group>"; };
 		D418D10520AC68B2006369C0 /* TraceAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceAnimation.swift; sourceTree = "<group>"; };
 		D418D12220ACDB76006369C0 /* Dictionary+AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+AttributedString.swift"; sourceTree = "<group>"; };
+		D43ADBD620AF60DF007519F7 /* TraceUIToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceUIToastView.swift; sourceTree = "<group>"; };
+		D43ADBD820AF60EB007519F7 /* TraceUIToastPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceUIToastPresenter.swift; sourceTree = "<group>"; };
+		D43ADBDA20AF60F9007519F7 /* TraceUIToastViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceUIToastViewModel.swift; sourceTree = "<group>"; };
+		D43ADBDC20AF6321007519F7 /* TraceUIToastQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceUIToastQueue.swift; sourceTree = "<group>"; };
+		D43ADBDE20AF64A5007519F7 /* TraceUIToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceUIToast.swift; sourceTree = "<group>"; };
 		D45FEC64209345380084DF96 /* Trace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trace.swift; sourceTree = "<group>"; };
 		D45FEC68209346220084DF96 /* TraceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceItem.swift; sourceTree = "<group>"; };
 		D4631753209232FD0008A1BC /* Tracer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tracer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -245,6 +255,7 @@
 				D417C85320A623D5000C1AE2 /* Misc */,
 				D4045CFD20A63BFB00BD8571 /* Settings */,
 				D417C83820A480A7000C1AE2 /* Tabs */,
+				D43ADBD520AF60C7007519F7 /* Toasts */,
 				D417C7ED20A1EE31000C1AE2 /* Traces */,
 				D4B608BE20AB3BB200F875F7 /* Window */,
 				D417C84720A49609000C1AE2 /* TraceUI.xcassets */,
@@ -332,6 +343,18 @@
 				D418D10520AC68B2006369C0 /* TraceAnimation.swift */,
 			);
 			path = Misc;
+			sourceTree = "<group>";
+		};
+		D43ADBD520AF60C7007519F7 /* Toasts */ = {
+			isa = PBXGroup;
+			children = (
+				D43ADBD820AF60EB007519F7 /* TraceUIToastPresenter.swift */,
+				D43ADBD620AF60DF007519F7 /* TraceUIToastView.swift */,
+				D43ADBDA20AF60F9007519F7 /* TraceUIToastViewModel.swift */,
+				D43ADBDC20AF6321007519F7 /* TraceUIToastQueue.swift */,
+				D43ADBDE20AF64A5007519F7 /* TraceUIToast.swift */,
+			);
+			path = Toasts;
 			sourceTree = "<group>";
 		};
 		D4631749209232FD0008A1BC = {
@@ -518,6 +541,7 @@
 				D4045CF420A62E4900BD8571 /* Dictionary+ItemLogger.swift in Sources */,
 				D45FEC69209346220084DF96 /* TraceItem.swift in Sources */,
 				D4873FC020AA0F0100B96BE6 /* TraceDragIndicatorTouchView.swift in Sources */,
+				D43ADBD920AF60EB007519F7 /* TraceUIToastPresenter.swift in Sources */,
 				D4873FBC20A9E0F700B96BE6 /* TraceUIPresenter.swift in Sources */,
 				D417C83120A39C9C000C1AE2 /* ItemLoggerListView.swift in Sources */,
 				D4045D0B20A9CD8500BD8571 /* TraceUISplitView.swift in Sources */,
@@ -556,9 +580,12 @@
 				D417C80B20A205D4000C1AE2 /* TraceUIDetailViewModel.swift in Sources */,
 				D4873FBE20AA0AAF00B96BE6 /* TraceUIViewModel.swift in Sources */,
 				D41115EE2097AFB800702064 /* TraceStates.swift in Sources */,
+				D43ADBDB20AF60F9007519F7 /* TraceUIToastViewModel.swift in Sources */,
 				D417C7E920A1E98E000C1AE2 /* TraceUISignals.swift in Sources */,
 				D4045D0920A643D500BD8571 /* TraceUISettingsViewModel.swift in Sources */,
+				D43ADBDF20AF64A5007519F7 /* TraceUIToast.swift in Sources */,
 				D417C82220A38C4E000C1AE2 /* TraceUIDetailHeaderView.swift in Sources */,
+				D43ADBDD20AF6321007519F7 /* TraceUIToastQueue.swift in Sources */,
 				D4045CF820A62F7100BD8571 /* ItemLoggerReport.swift in Sources */,
 				D4045D0320A63E2C00BD8571 /* String+CSV.swift in Sources */,
 				D417C7F320A1EF6C000C1AE2 /* TraceUIListViewModel.swift in Sources */,
@@ -571,6 +598,7 @@
 				D4045CF620A62EAD00BD8571 /* TraceDateFormatter.swift in Sources */,
 				D417C7F120A1EF04000C1AE2 /* TraceUIListPresenter.swift in Sources */,
 				D417C83C20A48490000C1AE2 /* TraceUITabView.swift in Sources */,
+				D43ADBD720AF60DF007519F7 /* TraceUIToastView.swift in Sources */,
 				D417C7EC20A1EB49000C1AE2 /* TraceUIProtocols.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/UI/Container/TraceUIContainerPresenter.swift
+++ b/UI/Container/TraceUIContainerPresenter.swift
@@ -70,6 +70,10 @@ private extension TraceUIContainerPresenter {
         TraceUISignals.UI.statusButtonDragged.listen { tuple in
             self.view.handleButtonDrag(with: tuple.touchPoint, gestureState: tuple.gestureState)
         }
+        
+        TraceUISignals.Toasts.show.listen { toast in
+            self.view.show(toast: toast)
+        }
     }
     
 }

--- a/UI/Extensions/Dictionary+AttributedString.swift
+++ b/UI/Extensions/Dictionary+AttributedString.swift
@@ -13,7 +13,10 @@ internal extension Dictionary where Key: ExpressibleByStringLiteral, Value: Cust
     
     func attributedLoggerDescription(fontSize: CGFloat) -> NSAttributedString {
         let v = NSMutableAttributedString(string: "")
-        let boldAttribute: [NSAttributedStringKey: Any] = [.font: UIFont.boldSystemFont(ofSize: fontSize)]
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .left
+        let boldAttribute: [NSAttributedStringKey: Any] = [.paragraphStyle: paragraph,
+                                                           .font: UIFont.boldSystemFont(ofSize: fontSize)]
         for (key, value) in self {
             let boldString = NSAttributedString(string: "\(key)", attributes: boldAttribute)
             v.append(boldString)

--- a/UI/Toasts/TraceUIToast.swift
+++ b/UI/Toasts/TraceUIToast.swift
@@ -1,0 +1,77 @@
+//
+//  TraceUIToast.swift
+//  Tracer
+//
+//  Created by Rob Phillips on 5/18/18.
+//  Copyright © 2018 Keepsafe Inc. All rights reserved.
+//
+
+import Foundation
+
+final class TraceUIToast: Operation {
+    
+    init(viewModel: TraceUIToastViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    // MARK: - API
+    
+    func finish() {
+        isExecuting = false
+        isFinished = true
+    }
+    
+    // MARK: - Properties
+    
+    lazy var view: TraceUIToastView = { [unowned self] in
+        return TraceUIToastView(viewModel: self.viewModel)
+    }()
+    
+    // MARK: - Overrides
+    
+    override var isFinished: Bool {
+        get { return _finished }
+        set {
+            willChangeValue(forKey: #function)
+            _finished = newValue
+            didChangeValue(forKey: #function)
+        }
+    }
+    
+    override var isExecuting: Bool {
+        get { return _executing }
+        set {
+            willChangeValue(forKey: #function)
+            _executing = newValue
+            didChangeValue(forKey: #function)
+        }
+    }
+    
+    override func start() {
+        guard (isFinished == false && isCancelled == false && isExecuting == false) else { return }
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.start() }
+            return
+        }
+        main()
+    }
+    
+    override func main() {
+        isExecuting = true
+        TraceUISignals.Toasts.show.fire(data: self)
+    }
+    
+    override func cancel() {
+        finish()
+        super.cancel()
+        view.removeFromSuperview()
+    }
+    
+    // MARK: - Private Properties
+    
+    private let viewModel: TraceUIToastViewModel
+    
+    private var _finished = false
+    private var _executing = false
+    
+}

--- a/UI/Toasts/TraceUIToastPresenter.swift
+++ b/UI/Toasts/TraceUIToastPresenter.swift
@@ -1,0 +1,41 @@
+//
+//  TraceUIToastPresenter.swift
+//  Tracer
+//
+//  Created by Rob Phillips on 5/18/18.
+//  Copyright © 2018 Keepsafe Inc. All rights reserved.
+//
+
+import UIKit
+
+final class TraceUIToastPresenter: Presenting {
+    
+    init(queue: TraceUIToastQueue = TraceUIToastQueue()) {
+        self.queue = queue
+        
+        listenForChanges()
+    }
+    
+    // MARK: - Private Properties
+    
+    private let queue: TraceUIToastQueue
+    private var showToasts = true
+    
+}
+
+private extension TraceUIToastPresenter {
+    func listenForChanges() {
+        TraceUISignals.Toasts.enable.listen { _ in
+            self.showToasts = true
+        }
+        TraceUISignals.Toasts.queue.listen { loggedItem in
+            guard self.showToasts else { return }
+            let viewModel = TraceUIToastViewModel(loggedItem: loggedItem)
+            self.queue.queue(toast: TraceUIToast(viewModel: viewModel))
+        }
+        TraceUISignals.Toasts.disable.listen { _ in
+            self.showToasts = false
+            self.queue.cancelAll()
+        }
+    }
+}

--- a/UI/Toasts/TraceUIToastQueue.swift
+++ b/UI/Toasts/TraceUIToastQueue.swift
@@ -1,0 +1,35 @@
+//
+//  TraceUIToastQueue.swift
+//  Tracer
+//
+//  Created by Rob Phillips on 5/18/18.
+//  Copyright © 2018 Keepsafe Inc. All rights reserved.
+//
+
+import Foundation
+
+final class TraceUIToastQueue {
+    
+    // MARK: - Instantiation
+    
+    init() {}
+    
+    // MARK: - API
+    
+    func queue(toast: TraceUIToast) {
+        queue.addOperation(toast)
+    }
+    
+    func cancelAll() {
+        queue.cancelAllOperations()
+    }
+    
+    // MARK: - Private Properties
+    
+    private let queue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
+    
+}

--- a/UI/Toasts/TraceUIToastView.swift
+++ b/UI/Toasts/TraceUIToastView.swift
@@ -1,0 +1,74 @@
+//
+//  TraceUIToastView.swift
+//  Tracer
+//
+//  Created by Rob Phillips on 5/18/18.
+//  Copyright © 2018 Keepsafe Inc. All rights reserved.
+//
+
+import UIKit
+
+final class TraceUIToastView: UIView, Viewing {
+    
+    init(viewModel: TraceUIToastViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(frame: .zero)
+        
+        setupView()
+    }
+    
+    // MARK: - Private Properties
+    
+    private let viewModel: TraceUIToastViewModel
+    
+    private lazy var textLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.backgroundColor = .clear
+        label.font = .systemFont(ofSize: 12)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        return label
+    }()
+    
+    // MARK: - Unsupported Initializers
+    
+    required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    
+}
+
+private extension TraceUIToastView {
+    
+    func setupView() {
+        isUserInteractionEnabled = false
+        
+        let attributedText = NSMutableAttributedString(string: "\(viewModel.loggedItem.item)")
+        if let properties = viewModel.loggedItem.properties {
+            attributedText.append(NSAttributedString(string: "\n\n"))
+            attributedText.append(properties.attributedLoggerDescription(fontSize: 12))
+        }
+        textLabel.attributedText = attributedText
+        
+        backgroundColor = UIColor.TraceUI.darkBlueGray.withAlphaComponent(0.7)
+        layer.cornerRadius = 5
+        
+        let screenSize = UIScreen.main.bounds.size
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(textLabel)
+        
+        let superview = self
+        NSLayoutConstraint.activate([textLabel.topAnchor.constraint(equalTo: superview.topAnchor, constant: 8),
+                                     textLabel.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -8),
+                                     textLabel.leftAnchor.constraint(equalTo: superview.leftAnchor, constant: 10),
+                                     textLabel.rightAnchor.constraint(equalTo: superview.rightAnchor, constant: -10)])
+        
+        let maxWidth: CGFloat = screenSize.width * 0.875
+        let maxHeight: CGFloat = screenSize.height * 0.875
+        NSLayoutConstraint.activate([superview.widthAnchor.constraint(lessThanOrEqualToConstant: maxWidth),
+                                     superview.heightAnchor.constraint(lessThanOrEqualToConstant: maxHeight),
+                                     superview.widthAnchor.constraint(greaterThanOrEqualToConstant: 100),
+                                     superview.heightAnchor.constraint(greaterThanOrEqualToConstant: 40)])
+    }
+    
+}

--- a/UI/Toasts/TraceUIToastViewModel.swift
+++ b/UI/Toasts/TraceUIToastViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  TraceUIToastViewModel.swift
+//  Tracer
+//
+//  Created by Rob Phillips on 5/18/18.
+//  Copyright © 2018 Keepsafe Inc. All rights reserved.
+//
+
+import Foundation
+
+struct TraceUIToastViewModel: ViewModeling {
+    let loggedItem: LoggedItem
+}

--- a/UI/TraceUI.swift
+++ b/UI/TraceUI.swift
@@ -119,6 +119,8 @@ public final class TraceUI: Listening {
         }
         logger.log(item: loggedItem)
         TraceUISignals.Logger.itemLogged.fire(data: loggedItem)
+        
+        TraceUISignals.Toasts.queue.fire(data: loggedItem)
     }
     
     /// Clears the tailing log

--- a/UI/TraceUISignals.swift
+++ b/UI/TraceUISignals.swift
@@ -46,5 +46,12 @@ internal struct TraceUISignals {
         static let statusButtonDragged = TraceSignal<(touchPoint: CGPoint, gestureState: UIGestureRecognizerState)>()
     }
     
+    internal struct Toasts {
+        static let enable = TraceActionSignal()
+        static let queue = TraceSignal<LoggedItem>()
+        static let show = TraceSignal<TraceUIToast>()
+        static let disable = TraceActionSignal()
+    }
+    
     private init() {}
 }


### PR DESCRIPTION
### Changes

- Shows toast messages when the tool is collapsed
- Uses a serial queue and each toast is displayed for 2 seconds
- Dismisses and cancels queued toasts when tool is expanded

### Demo

![demo](https://user-images.githubusercontent.com/30269720/40259312-8f57a4c6-5ac3-11e8-945a-3feca0873d8a.gif)


